### PR TITLE
Add hidden labels for task inputs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,9 @@
     <main class="container">
       <section class="controls">
         <form id="new-task-form" autocomplete="off">
+          <label for="task-title" class="visually-hidden">Task title</label>
           <input id="task-title" name="title" type="text" placeholder="Add a task" required maxlength="200" />
+          <label for="task-when" class="visually-hidden">When</label>
           <input id="task-when" name="when" type="datetime-local" />
           <button type="submit" class="primary">Add</button>
         </form>

--- a/public/styles.css
+++ b/public/styles.css
@@ -12,6 +12,18 @@
   --radius: 14px;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 * { box-sizing: border-box; }
 html, body { height: 100%; }
 body {


### PR DESCRIPTION
## Summary
- add visually hidden labels for new-task title and datetime inputs
- include CSS helper to hide labels visually while remaining accessible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b642b65f7c832b9401b0be1e06c486