### PR TITLE
Add Netlify serverless API handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ No accounts by default. Local IndexedDB storage. Server only handles push schedu
 Any Node host works. The server serves static files from ./public and exposes /api for push.
 Use a reverse proxy for TLS.
 
+### Serverless (Netlify)
+
+For a lightweight deployment, a Netlify Function is provided in `netlify/functions/api.js`.
+It handles `/api/subscribe` and `/api/schedule` and can be used instead of the Node server.
+
+1. Deploy the static site from the `public/` directory.
+2. Include the provided `netlify.toml` so requests to `/api/*` are routed to the function.
+3. Set `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` environment variables in your Netlify project.
+
+The client uses relative `/api` URLs, so when the function and static site share a domain,
+the app automatically points to the serverless endpoint.
+
 ## Structure
 
 - `public/` client app, PWA assets

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = ""
+  publish = "public"
+
+[functions]
+  directory = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/api/:splat"
+  status = 200

--- a/netlify/functions/api.js
+++ b/netlify/functions/api.js
@@ -1,0 +1,70 @@
+import webpush from 'web-push';
+import schedule from 'node-schedule';
+import { Subscriptions, Schedules } from '../../db.js';
+
+const VAPID_PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY || '';
+const VAPID_PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY || '';
+
+if (VAPID_PUBLIC_KEY && VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails('mailto:admin@example.com', VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY);
+}
+
+export async function handler(event) {
+  const { httpMethod, path } = event;
+  const payload = event.body ? JSON.parse(event.body) : null;
+
+  if (path.endsWith('/subscribe') && httpMethod === 'POST') {
+    const sub = payload;
+    if (!sub || !sub.endpoint || !sub.keys) {
+      return jsonResponse(400, { error: 'invalid subscription' });
+    }
+    const id = Subscriptions.upsert(sub);
+    return jsonResponse(200, { id });
+  }
+
+  if (path.endsWith('/schedule') && httpMethod === 'POST') {
+    if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
+      return jsonResponse(400, { error: 'push not configured' });
+    }
+    const { subscription_id, task_id, title, body, fire_at } = payload || {};
+    if (!subscription_id || !task_id || !title || !fire_at) {
+      return jsonResponse(400, { error: 'missing fields' });
+    }
+    const when = Number(fire_at);
+    if (!Number.isFinite(when) || when < Date.now() + 1000) {
+      return jsonResponse(400, { error: 'fire_at must be in the future' });
+    }
+    const id = Schedules.insert({ subscription_id, task_id, title, body, fire_at: when });
+    const sub = Subscriptions.getById(subscription_id);
+    scheduleNotification({ scheduleId: id, sub, title, body, fire_at: when });
+    return jsonResponse(200, { id });
+  }
+
+  return { statusCode: 404, body: 'Not found' };
+}
+
+function jsonResponse(statusCode, obj) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(obj)
+  };
+}
+
+function scheduleNotification({ scheduleId, sub, title, body, fire_at }) {
+  const date = new Date(fire_at);
+  schedule.scheduleJob(`schedule_${scheduleId}`, date, async () => {
+    try {
+      await webpush.sendNotification(
+        {
+          endpoint: sub.endpoint,
+          keys: { p256dh: sub.p256dh, auth: sub.auth }
+        },
+        JSON.stringify({ title, body })
+      );
+      Schedules.markSent(scheduleId);
+    } catch (err) {
+      console.error('push error', err?.message);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add Netlify Function providing `/api/subscribe` and `/api/schedule`
- document serverless deployment and Netlify configuration

## Testing
- `node --check netlify/functions/api.js`
- `node -e "import('./netlify/functions/api.js').then(m=>console.log('handler:', typeof m.handler))"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b642b89afc832bbdb9b4cd2f8f6920