### PR TITLE
feat: separate reminder field

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
         <form id="new-task-form" autocomplete="off">
           <input id="task-title" name="title" type="text" placeholder="Add a task" required maxlength="200" />
           <input id="task-when" name="when" type="datetime-local" />
+          <input id="task-remind" name="remindAt" type="datetime-local" />
           <button type="submit" class="primary">Add</button>
         </form>
         <div class="bar">

--- a/public/main.js
+++ b/public/main.js
@@ -103,7 +103,10 @@ async function render() {
     const snooze = node.querySelector('.snooze');
 
     title.textContent = t.title;
-    whenEl.textContent = t.remindAt ? `remind ${fmtWhen(t.remindAt)}` : (t.dueAt ? `due ${fmtWhen(t.dueAt)}` : '');
+    const parts = [];
+    if (t.remindAt) parts.push(`remind ${fmtWhen(t.remindAt)}`);
+    if (t.dueAt) parts.push(`due ${fmtWhen(t.dueAt)}`);
+    whenEl.textContent = parts.join(' \u2022 ');
     toggle.checked = !!t.completed;
 
     toggle.addEventListener('change', async () => {
@@ -227,7 +230,8 @@ $('#new-task-form').addEventListener('submit', async (e) => {
   if (!title) return;
   const whenVal = $('#task-when').value;
   const dueAt = whenVal ? new Date(whenVal).getTime() : null;
-  const remindAt = dueAt; // simple default
+  const remindVal = $('#task-remind').value;
+  const remindAt = remindVal ? new Date(remindVal).getTime() : null;
   const t = {
     id: crypto.randomUUID(),
     title,
@@ -240,6 +244,7 @@ $('#new-task-form').addEventListener('submit', async (e) => {
   await store.put(t);
   $('#task-title').value = '';
   $('#task-when').value = '';
+  $('#task-remind').value = '';
   schedule(t);
   render();
 });


### PR DESCRIPTION
## Summary
- add separate `remindAt` input for new tasks
- parse and store dedicated reminder time independent of due date
- display both reminder and due times in task list

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b642b98c00832ba3ca1bc69efa5d68